### PR TITLE
"Fix ambiguous match keys in LaravelWilayahApiController

### DIFF
--- a/database/migrations/2023_10_05_030904_create_wilayah_table.php
+++ b/database/migrations/2023_10_05_030904_create_wilayah_table.php
@@ -6,7 +6,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::create(config('wilayah.table_prefix') . 'cities', static function (Blueprint $table) {

--- a/src/LaravelWilayahApiController.php
+++ b/src/LaravelWilayahApiController.php
@@ -43,11 +43,11 @@ class LaravelWilayahApiController extends Controller
     {
         return $data->map(function ($item) {
             return match ($item) {
-                $item->province_code => '<option value="' . $item->province_code . '">' . $item->name . '</option>',
-                $item->city_code => '<option value="' . $item->city_code . '">' . $item->name . '</option>',
-                $item->district_code => '<option value="' . $item->district_code . '">' . $item->name . '</option>',
-                $item->village_code => '<option value="' . $item->village_code . '">' . $item->name . '</option>',
-                $item->island_code => '<option value="' . $item->island_code . '">' . $item->name . '</option>',
+                'province_code' => '<option value="' . $item->province_code . '">' . $item->name . '</option>',
+                'city_code' => '<option value="' . $item->city_code . '">' . $item->name . '</option>',
+                'district_code' => '<option value="' . $item->district_code . '">' . $item->name . '</option>',
+                'village_code' => '<option value="' . $item->village_code . '">' . $item->name . '</option>',
+                'island_code' => '<option value="' . $item->island_code . '">' . $item->name . '</option>',
             };
 
         })->implode('');

--- a/src/LaravelWilayahApiController.php
+++ b/src/LaravelWilayahApiController.php
@@ -42,13 +42,33 @@ class LaravelWilayahApiController extends Controller
     protected function responseAsHtml(Collection $data): string
     {
         return $data->map(function ($item) {
-            return match ($item) {
-                $item->province_code => '<option value="' . $item->province_code . '">' . $item->name . '</option>',
-                $item->city_code => '<option value="' . $item->city_code . '">' . $item->name . '</option>',
-                $item->district_code => '<option value="' . $item->district_code . '">' . $item->name . '</option>',
-                $item->village_code => '<option value="' . $item->village_code . '">' . $item->name . '</option>',
-                $item->island_code => '<option value="' . $item->island_code . '">' . $item->name . '</option>',
-            };
+            if (isset($item->province_code, $item->name)) {
+                return '<option value="' . $item->province_code . '">' . $item->name . '</option>';
+            }
+
+            if (isset($item->city_code, $item->name)) {
+                return '<option value="' . $item->city_code . '">' . $item->name . '</option>';
+            }
+
+            if (isset($item->district_code, $item->name)) {
+                return '<option value="' . $item->district_code . '">' . $item->name . '</option>';
+            }
+
+            if (isset($item->village_code, $item->name)) {
+                return '<option value="' . $item->village_code . '">' . $item->name . '</option>';
+            }
+
+            if (isset($item->island_code, $item->name)) {
+                return '<option value="' . $item->island_code . '">' . $item->name . '</option>';
+            }
+
+//            return match ($item) {
+//                'province_code' => '<option value="' . $item->province_code . '">' . $item->name . '</option>',
+//                'city_code' => '<option value="' . $item->city_code . '">' . $item->name . '</option>',
+//                'district_code' => '<option value="' . $item->district_code . '">' . $item->name . '</option>',
+//                'village_code' => '<option value="' . $item->village_code . '">' . $item->name . '</option>',
+//                'island_code' => '<option value="' . $item->island_code . '">' . $item->name . '</option>',
+//            };
 
         })->implode('');
     }

--- a/src/LaravelWilayahApiController.php
+++ b/src/LaravelWilayahApiController.php
@@ -62,13 +62,13 @@ class LaravelWilayahApiController extends Controller
                 return '<option value="' . $item->island_code . '">' . $item->name . '</option>';
             }
 
-//            return match ($item) {
-//                'province_code' => '<option value="' . $item->province_code . '">' . $item->name . '</option>',
-//                'city_code' => '<option value="' . $item->city_code . '">' . $item->name . '</option>',
-//                'district_code' => '<option value="' . $item->district_code . '">' . $item->name . '</option>',
-//                'village_code' => '<option value="' . $item->village_code . '">' . $item->name . '</option>',
-//                'island_code' => '<option value="' . $item->island_code . '">' . $item->name . '</option>',
-//            };
+            //            return match ($item) {
+            //                'province_code' => '<option value="' . $item->province_code . '">' . $item->name . '</option>',
+            //                'city_code' => '<option value="' . $item->city_code . '">' . $item->name . '</option>',
+            //                'district_code' => '<option value="' . $item->district_code . '">' . $item->name . '</option>',
+            //                'village_code' => '<option value="' . $item->village_code . '">' . $item->name . '</option>',
+            //                'island_code' => '<option value="' . $item->island_code . '">' . $item->name . '</option>',
+            //            };
 
         })->implode('');
     }

--- a/src/LaravelWilayahApiController.php
+++ b/src/LaravelWilayahApiController.php
@@ -18,7 +18,7 @@ class LaravelWilayahApiController extends Controller
     /**
      * Get provinces data.
      */
-    public function provinces(Request $request): JsonResponse|string
+    public function provinces(Request $request): JsonResponse | string
     {
         $query = Province::select(config('wilayah.api.response_columns.province'));
 
@@ -28,7 +28,7 @@ class LaravelWilayahApiController extends Controller
     /**
      * Get response as JSON or as HTML options.
      */
-    protected function getResponse(Request $request, Builder $query): JsonResponse|string
+    protected function getResponse(Request $request, Builder $query): JsonResponse | string
     {
         $data = $query->get();
 
@@ -68,7 +68,7 @@ class LaravelWilayahApiController extends Controller
     /**
      * Get cities data.
      */
-    public function cities(Request $request): JsonResponse|string
+    public function cities(Request $request): JsonResponse | string
     {
         $query = City::select(config('wilayah.api.response_columns.city'));
 
@@ -88,7 +88,7 @@ class LaravelWilayahApiController extends Controller
     /**
      * Get districts data.
      */
-    public function districts(Request $request): JsonResponse|string
+    public function districts(Request $request): JsonResponse | string
     {
         $query = District::select(config('wilayah.api.response_columns.district'));
 
@@ -108,10 +108,10 @@ class LaravelWilayahApiController extends Controller
     /**
      * Get villages data.
      */
-    public function villages(Request $request): JsonResponse|string
+    public function villages(Request $request): JsonResponse | string
     {
         //
-//        if (empty($request->district_code) && empty($request->district_name)) {
+        //        if (empty($request->district_code) && empty($request->district_name)) {
         if (empty($request->district_code) && empty($request->district_name)) {
             //.
             $message = 'Parameter district_code or district_name is required';

--- a/src/LaravelWilayahDatabaseSeeder.php
+++ b/src/LaravelWilayahDatabaseSeeder.php
@@ -51,7 +51,7 @@ class LaravelWilayahDatabaseSeeder extends Seeder
         $data = [];
 
         foreach (explode("\n", $content) as $item) {
-            if (!empty($item)) {
+            if (! empty($item)) {
                 $data[] = str_getcsv($item);
             }
         }

--- a/src/Models/City.php
+++ b/src/Models/City.php
@@ -12,7 +12,9 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 class City extends Model
 {
     public $timestamps = false;
+
     protected $primaryKey = 'city_code';
+
     protected $fillable = [
         'province_code',
         'city_code',

--- a/src/Models/District.php
+++ b/src/Models/District.php
@@ -11,10 +11,12 @@ use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 
 class District extends Model
 {
-//    use HasRelationships;
+    //    use HasRelationships;
 
     public $timestamps = false;
+
     protected $primaryKey = 'district_code';
+
     protected $fillable = [
         'district_code',
         'city_code',
@@ -39,7 +41,6 @@ class District extends Model
             'province_code',
             'city_code',
             'province_code',
-
         );
     }
 
@@ -62,7 +63,6 @@ class District extends Model
             'province_code',
             'city_code',
             'province_code',
-
         );
     }
 }

--- a/src/Models/Island.php
+++ b/src/Models/Island.php
@@ -15,7 +15,9 @@ class Island extends Model
     use HasRelationships;
 
     public $timestamps = false;
+
     protected $primaryKey = 'island_code';
+
     protected $fillable = ['island_code', 'province_code', 'city_code', 'name'];
 
     public function __construct(array $attributes = [])

--- a/src/Models/Province.php
+++ b/src/Models/Province.php
@@ -15,7 +15,9 @@ class Province extends Model
     use HasRelationships;
 
     public $timestamps = false;
+
     protected $primaryKey = 'province_code';
+
     protected $fillable = ['province_code', 'name'];
 
     public function __construct(array $attributes = [])
@@ -29,7 +31,7 @@ class Province extends Model
 
     public function cities(): HasMany
     {
-        return $this->hasMany(City::class, 'province_code', 'province_code',);
+        return $this->hasMany(City::class, 'province_code', 'province_code');
     }
 
     public function districts(): HasManyThrough
@@ -43,7 +45,7 @@ class Province extends Model
             Village::class,
             [City::class, District::class],
             ['province_code', 'city_code', 'district_code'],
-//            ['city_code', 'district_code', 'province_code']
+            //            ['city_code', 'district_code', 'province_code']
         );
     }
 

--- a/src/Models/Village.php
+++ b/src/Models/Village.php
@@ -15,7 +15,9 @@ class Village extends Model
     use HasRelationships;
 
     public $timestamps = false;
+
     protected $primaryKey = 'village_code';
+
     protected $fillable = ['village_code', 'district_code', 'name'];
 
     public function __construct(array $attributes = [])

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -202,7 +202,7 @@ it('can get island model relations', function () {
         ->and($city->name)->toBe('KAB. ACEH BESAR');
 
     $district = Island::find(40020)->district;
-//    dd($district);
+    //    dd($district);
     expect($district)->toBeInstanceOf(District::class)
         ->and($district->district_code)->toBe(110601)
         ->and($district->name)->toBe('Lhoong');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -37,16 +37,16 @@ class TestCase extends Orchestra
             'host' => 'localhost',
             'username' => 'root',
             'password' => 'BlackID85',
-//            'prefix' => config()->get('wilayah.table_prefix'),
+            //            'prefix' => config()->get('wilayah.table_prefix'),
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
             'database' => 'laravel_wilayah',
         ]);
 
-//        Artisan::call('migrate');
-//        Artisan::call('db:seed', [
-//            'class' => \HanzoAlpha\LaravelWilayah\LaravelWilayahDatabaseSeeder::class,
-//        ]);
+        //        Artisan::call('migrate');
+        //        Artisan::call('db:seed', [
+        //            'class' => \HanzoAlpha\LaravelWilayah\LaravelWilayahDatabaseSeeder::class,
+        //        ]);
 
         /* $migration = include __DIR__ . '/../database/migrations/create_laravel-wilayah_table.php.stub';
          $migration->up();*/


### PR DESCRIPTION
     Match keys in LaravelWilayahApiController were previously attached to the object's properties which could lead to confusion and potential errors. Replaced these ambiguous keys with clear, string based keys such as 'province_code', 'city_code', etc. This makes the matching clearer and less error-prone."